### PR TITLE
Set \interlinepenalty 0 after bibliography to avoid wrong page breaks…

### DIFF
--- a/WissBer_PA_SA_BA.tex
+++ b/WissBer_PA_SA_BA.tex
@@ -231,6 +231,7 @@ marginal
 % ---- Literaturverzeichnis ----------
 \interlinepenalty 10000					% Verhindert einen Umbruch mitten in Literatureinträgen
 \printbibliography						% Erstellen des Literaturverzeichnisses
+\interlinepenalty 0
 \clearpage
 
 % -----Ausgabe aller Verzeichnisse ---


### PR DESCRIPTION
… in the appendix